### PR TITLE
Add Static Plotly Figure Return Type

### DIFF
--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -1544,10 +1544,8 @@ def boxplot_interactive(
 
     Returns
     -------
-    fig : plotly.graph_objects.Figure or str
-        The generated boxplot figure, which can be either:
-            - If not `interactive`: A base64-encoded PNG image string
-            - If `interactive`: A Plotly figure object
+    fig : plotly.graph_objects.Figure
+        The generated boxplot figure
 
     df : pd.DataFrame
         A DataFrame containing the features and their corresponding values.
@@ -1879,9 +1877,26 @@ def boxplot_interactive(
     if interactive:
         plot = fig
     else:
-        # Convert Plotly to PNG encoded to base64
-        img_bytes = pio.to_image(fig, format="png")
-        plot = base64.b64encode(img_bytes).decode("utf-8")
+        # Disable interactive components
+        config = {
+            'dragmode': False,
+            'hovermode': False,
+            'clickmode': 'none',
+            'modebar_remove': [
+                'toimage', 
+                'zoom', 
+                'zoomin', 
+                'zoomout',
+                'select', 
+                'pan', 
+                'lasso', 
+                'autoscale', 
+                'resetscale'
+            ],
+            'legend_itemclick': False,
+            'legend_itemdoubleclick': False
+        }
+        plot = fig.update_layout(**config)
 
     logging.info(
         "Time taken to generate boxplot: %f seconds",

--- a/src/spac/visualization.py
+++ b/src/spac/visualization.py
@@ -1461,7 +1461,7 @@ def boxplot_interactive(
     defined_color_map=None,
     annotation_colorscale="viridis",
     feature_colorscale="seismic",
-    interactive=True,
+    figure_type="interactive",
     return_metrics=False,
     **kwargs,
 ):
@@ -1532,9 +1532,11 @@ def boxplot_interactive(
         Name of the color scale to use for the dots when feature
         is used.
 
-    interactive : bool, default = False
-        If True, the plot is interactive, allowing for zooming and panning.
-        If False, the plot is static.
+    figure_type : {"interactive", "static", "png"}, default = "interactive"
+        If "interactive", the plot is interactive, allowing for zooming 
+        and panning.
+        If "static", the plot is static.
+        If "png", the plot is returned as a PNG image.
 
     return_metrics: bool, default = False
         If True, the function returns the computed boxplot metrics.
@@ -1544,8 +1546,10 @@ def boxplot_interactive(
 
     Returns
     -------
-    fig : plotly.graph_objects.Figure
-        The generated boxplot figure
+    fig : plotly.graph_objects.Figure or str
+        The generated boxplot figure, which can be either:
+            - If `figure_type` is "static": A base64-encoded PNG image string
+            - If `figure_type` is "interactive": A Plotly figure object
 
     df : pd.DataFrame
         A DataFrame containing the features and their corresponding values.
@@ -1796,6 +1800,11 @@ def boxplot_interactive(
             ("Got {showfliers}."),
         )
 
+    if figure_type not in ("interactive", "static", "png"):
+        raise ValueError(
+            "figure_type must be one of 'interactive', 'static', or 'png'."
+        )
+
     # Extract data from the specified layer or the default matrix (adata.X)
     if layer:
         data_matrix = adata.layers[layer]
@@ -1874,9 +1883,13 @@ def boxplot_interactive(
     )
 
     # Prepare the base image or figure return value
-    if interactive:
+    if figure_type == "interactive":
         plot = fig
-    else:
+    elif figure_type == "png":
+        # Convert Plotly to PNG encoded to base64
+        img_bytes = pio.to_image(fig, format="png")
+        plot = base64.b64encode(img_bytes).decode("utf-8")
+    elif figure_type == "static":
         # Disable interactive components
         config = {
             'dragmode': False,

--- a/tests/test_visualization/test_boxplot_interactive.py
+++ b/tests/test_visualization/test_boxplot_interactive.py
@@ -31,7 +31,7 @@ class TestBoxplotInteractive(unittest.TestCase):
         """Test if correct types are returned."""
         # Test non-interactive mode
         fig, df, metrics = boxplot_interactive(self.adata, interactive=False, return_metrics=True)
-        self.assertIsInstance(fig, str)
+        self.assertIsInstance(fig, go.Figure)
         self.assertIsInstance(df, pd.DataFrame)
         self.assertIsInstance(metrics, pd.DataFrame)
 

--- a/tests/test_visualization/test_boxplot_interactive.py
+++ b/tests/test_visualization/test_boxplot_interactive.py
@@ -29,15 +29,20 @@ class TestBoxplotInteractive(unittest.TestCase):
 
     def test_returns_correct_types(self):
         """Test if correct types are returned."""
-        # Test non-interactive mode
-        fig, df, metrics = boxplot_interactive(self.adata, interactive=False, return_metrics=True)
+        # Test interactive mode
+        fig, df, metrics = boxplot_interactive(self.adata, figure_type="interactive", return_metrics=True)
         self.assertIsInstance(fig, go.Figure)
         self.assertIsInstance(df, pd.DataFrame)
         self.assertIsInstance(metrics, pd.DataFrame)
 
-        # Test interactive mode
-        fig, df = boxplot_interactive(self.adata, interactive=True)
+        # Test non-interactive mode
+        fig, df = boxplot_interactive(self.adata, figure_type="static")
         self.assertIsInstance(fig, go.Figure)
+        self.assertIsInstance(df, pd.DataFrame)
+
+        # Test png mode
+        fig, df = boxplot_interactive(self.adata, figure_type="png")
+        self.assertIsInstance(fig, str)
         self.assertIsInstance(df, pd.DataFrame)
 
     def test_single_annotation_single_feature(self):
@@ -45,8 +50,7 @@ class TestBoxplotInteractive(unittest.TestCase):
         fig, df = boxplot_interactive(
             self.adata, features=['feature1'],
             annotation='phenotype',
-            orient='v',
-            interactive=True
+            orient='v'
         )
 
         # Get boxplot names from figure
@@ -63,8 +67,7 @@ class TestBoxplotInteractive(unittest.TestCase):
             self.adata,
             features=['feature1', 'feature2'],
             annotation='phenotype',
-            orient='v',
-            interactive=True,
+            orient='v'
         )
 
         # Get x-axis labels from figure
@@ -80,8 +83,7 @@ class TestBoxplotInteractive(unittest.TestCase):
         fig, df = boxplot_interactive(
             self.adata,
             features=['feature1', 'feature2'],
-            orient='v',
-            interactive=True,
+            orient='v'
         )
 
         #  Get x-axis labels from figure
@@ -97,7 +99,6 @@ class TestBoxplotInteractive(unittest.TestCase):
             self.adata, features=['feature1'],
             annotation='phenotype',
             orient='h',
-            interactive=True,
         )
         # Get y-axis labels from figure
         y_labels = [y_data for boxplot in fig.data for y_data in boxplot.y]
@@ -117,7 +118,6 @@ class TestBoxplotInteractive(unittest.TestCase):
             self.adata,
             features=['feature1'],
             log_scale=True,
-            interactive=True
         )
 
         # Check that the y-axis label is 'log(Intensity)'
@@ -140,8 +140,7 @@ class TestBoxplotInteractive(unittest.TestCase):
         fig, df = boxplot_interactive(
             self.adata,
             features=['feature1'],
-            log_scale=True,
-            interactive=True
+            log_scale=True
         )
 
         # Check that the y-axis label is still 'log(Intensity)'
@@ -215,8 +214,7 @@ class TestBoxplotInteractive(unittest.TestCase):
         fig, df = boxplot_interactive(
             adata,
             features=['feature1'],
-            log_scale=True,
-            interactive=True
+            log_scale=True
         )
 
         # Extract the printed messages
@@ -252,12 +250,12 @@ class TestBoxplotInteractive(unittest.TestCase):
             self.adata,
             features=['feature1'],
             orient='v',
-            interactive=True
+            figure_type="interactive"
         )
         self.assertEqual(fig.layout.yaxis.title.text, 'Intensity')
 
         # Test for horizontal orientation
-        fig, df = boxplot_interactive(self.adata, features=['feature1'], orient='h', interactive=True)
+        fig, df = boxplot_interactive(self.adata, features=['feature1'], orient='h', figure_type="interactive")
         self.assertEqual(fig.layout.xaxis.title.text, 'Intensity')
 
     def test_axis_labels(self):
@@ -268,7 +266,7 @@ class TestBoxplotInteractive(unittest.TestCase):
             features=['feature1'],
             annotation='phenotype',
             orient='v',
-            interactive=True
+            figure_type="interactive"
         )
         self.assertEqual(fig.layout.xaxis.title.text, 'phenotype')
         self.assertEqual(fig.layout.yaxis.title.text, 'Intensity')
@@ -280,7 +278,6 @@ class TestBoxplotInteractive(unittest.TestCase):
             annotation='phenotype',
             orient='v',
             log_scale=True,
-            interactive=True
         )
         self.assertEqual(fig.layout.xaxis.title.text, 'phenotype')
         self.assertEqual(fig.layout.yaxis.title.text, 'log(Intensity)')
@@ -291,7 +288,6 @@ class TestBoxplotInteractive(unittest.TestCase):
             features=['feature1'],
             annotation='phenotype',
             orient='h',
-            interactive=True
         )
         self.assertEqual(fig.layout.xaxis.title.text, 'Intensity')
         self.assertEqual(fig.layout.yaxis.title.text, 'phenotype')
@@ -303,7 +299,6 @@ class TestBoxplotInteractive(unittest.TestCase):
             annotation='phenotype',
             orient='h',
             log_scale=True,
-            interactive=True
         )
         self.assertEqual(fig.layout.xaxis.title.text, 'log(Intensity)')
         self.assertEqual(fig.layout.yaxis.title.text, 'phenotype')
@@ -314,7 +309,6 @@ class TestBoxplotInteractive(unittest.TestCase):
             self.adata,
             features=['feature1'],
             orient='v',
-            interactive=True,
         )
         x_labels = [x_data for boxplot in fig.data for x_data in boxplot.x]
         self.assertEqual(x_labels, ['feature1'])
@@ -323,7 +317,6 @@ class TestBoxplotInteractive(unittest.TestCase):
             self.adata,
             features=['feature1'],
             orient='h',
-            interactive=True,
         )
         y_labels = [y_data for boxplot in fig.data for y_data in boxplot.y]
         self.assertEqual(y_labels, ['feature1'])


### PR DESCRIPTION
## Summary
This PR removed the `interactive` parameter and adds a `figure_type` parameter. This still has the "interactive" and "png" options, but now has a "static" option which generates a static plotly figure. This can shave off >5 sec for the 10m dataset instead of converting the plotly figure to a PNG, and ideally should be used in Shiny over the png option.

## Changes
* Add new `figure_type` parameter and remove `interactive`
  * This new parameter allows the return plot to be plotly-interactive, plotly-static, and a png
 
* Transform static boxplot to plotly figure:
  * When `figure_type` is static, boxplot is kept as plotly figure
  * Disables (most) interactive features
    * The "This plot was made using plotly" button cannot be disabled
    * The cursor will still change when hovering over the plot, but it still can't be interacted with
