### PR TITLE
Addition of Unittest spatial plot list

### DIFF
--- a/tests/test_utils/test_get_defined_color_map.py
+++ b/tests/test_utils/test_get_defined_color_map.py
@@ -106,11 +106,11 @@ class TestGetDefinedColorMap(unittest.TestCase):
         Test handling of list-based annotations,
         raises a NotImplementedError.
         """
-        with self.assertRaises(NotImplementedError):
-            get_defined_color_map(
-                self.dummy_adata,
-                annotations=['cell_type', 'status'],
-            )
+        obs = {'my_ann': pd.Series(['a', 'b', 'a']), 'my_ann_2': pd.Series(['a', 'b', 'a'])}
+        dummy = DummyAnnData(uns={'dummy': {}}, obs=obs)
+        result = get_defined_color_map(dummy,
+                annotations=list(('my_ann', 'my_ann_2')))
+        self.assertIsNotNone(result)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_utils/test_get_defined_color_map.py
+++ b/tests/test_utils/test_get_defined_color_map.py
@@ -101,6 +101,16 @@ class TestGetDefinedColorMap(unittest.TestCase):
         ):
             get_defined_color_map(dummy, defined_color_map=None)
 
+    def test_generate_color_map_multiple_annotations(self):
+        """
+        Test handling of list-based annotations,
+        raises a NotImplementedError.
+        """
+        with self.assertRaises(NotImplementedError):
+            get_defined_color_map(
+                self.dummy_adata,
+                annotations=['cell_type', 'status'],
+            )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Unittest:

Tests the application of a list of annotations to the spatial plot in visualizations.py. This test determines that there is an output plot based on the list input.